### PR TITLE
[Fix] (Emergency Merge) Update pypa/gh-action-pypi-publish to version 1.12.4 in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Deploy package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
## Change Log
This pull request updates the PyPI publishing action in the GitHub deployment workflow to use a newer version. This ensures improved reliability and security for package deployments.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)